### PR TITLE
Converted Drawing/Point.cs to struct of shorts

### DIFF
--- a/Agent.Contrib/Drawing/Point.cs
+++ b/Agent.Contrib/Drawing/Point.cs
@@ -3,17 +3,28 @@ using Microsoft.SPOT;
 
 namespace Agent.Contrib.Drawing
 {
-    public class Point
+    public struct Point
     {
-
         public Point(int x = 0, int y = 0)
+        {
+            if (x > short.MaxValue)
+                throw new ArgumentOutOfRangeException("x");
+
+            if (y > short.MaxValue)
+                throw new ArgumentOutOfRangeException("y");
+
+            X = (short)x;
+            Y = (short)y;
+        }
+
+        public Point(short x = 0, short y = 0)
         {
             X = x;
             Y = y;
         }
 
-        public int X { get; set; }
-        public int Y { get; set; }
+        public short X;
+        public short Y;
 
 
     }

--- a/Agent.Contrib/Samples/MonthWatchFace/MonthFace.cs
+++ b/Agent.Contrib/Samples/MonthWatchFace/MonthFace.cs
@@ -78,7 +78,7 @@ namespace MonthWatchFace
                 days.Add(new Day()
                     {
                         Text = current.Day.ToString(),
-                        Point = new Point() { X=colPos,Y=rowPos},
+                        Point = new Point(colPos,rowPos),
                         Timestamp = current
                     });
 


### PR DESCRIPTION
Point has no methods and is used as a composite value so it makes more sense as a struct. Also since Point is used to represent a point on the screen, short made a little more sense (could conceivably use byte but there might be times that a point off the screen is desirable).

I removed the auto-properties as a consequence and had to alter one watch face to use the constructor instead of the properties. I left the construction of ints to reduce the number of code lines that need to be changed but added range checks to ensure we aren't accidentally truncating the value. Purely convenience.

Finally - I've never done a fork and pull before so I wanted to see what it's like.
