### PR TITLE
Dynamic refresh period

### DIFF
--- a/Agent.Contrib/Face/WatchFace.cs
+++ b/Agent.Contrib/Face/WatchFace.cs
@@ -12,15 +12,6 @@ namespace Agent.Contrib.Face
         public IFace Face { get; set; }
         public Bitmap Screen { get; set; }
 
-        /// <summary>
-        /// Reference to the internal timer used to refresh the face
-        /// </summary>
-        private Timer _timer;
-        /// <summary>
-        /// Timer interval in ms
-        /// </summary>
-        private int _timerPeriod;
-
         public void Render()
         {
 
@@ -35,12 +26,7 @@ namespace Agent.Contrib.Face
             //flush the image out to the device
             Screen.Flush();
 
-            //Update the timer period if it has been changed
-            if (_timerPeriod != Face.UpdateSpeed)
-            {
-                _timerPeriod = Face.UpdateSpeed;
-                _timer.Change(1, _timerPeriod);
-            }
+
         }
         public WatchFace(IFace face, Bitmap screen = null, ISettings settings = null)
         {            
@@ -58,14 +44,12 @@ namespace Agent.Contrib.Face
 
             // Included font is used in the clock
 
-            // Store the timer reference so we can change period later if required
-            _timerPeriod = Face.UpdateSpeed;
-            _timer = new Timer(state =>
+            var timer = new Timer(state =>
             {
 
-                Render();
+               Render();
 
-            }, null, 1, _timerPeriod);
+            }, null, 1, Face.UpdateSpeed);
             
             Thread.Sleep(Timeout.Infinite);
         }

--- a/Agent.Contrib/Face/WatchFace.cs
+++ b/Agent.Contrib/Face/WatchFace.cs
@@ -12,6 +12,15 @@ namespace Agent.Contrib.Face
         public IFace Face { get; set; }
         public Bitmap Screen { get; set; }
 
+        /// <summary>
+        /// Reference to the internal timer used to refresh the face
+        /// </summary>
+        private Timer _timer;
+        /// <summary>
+        /// Timer interval in ms
+        /// </summary>
+        private int _timerPeriod;
+
         public void Render()
         {
 
@@ -26,7 +35,12 @@ namespace Agent.Contrib.Face
             //flush the image out to the device
             Screen.Flush();
 
-
+            //Update the timer period if it has been changed
+            if (_timerPeriod != Face.UpdateSpeed)
+            {
+                _timerPeriod = Face.UpdateSpeed;
+                _timer.Change(1, _timerPeriod);
+            }
         }
         public WatchFace(IFace face, Bitmap screen = null, ISettings settings = null)
         {            
@@ -44,12 +58,15 @@ namespace Agent.Contrib.Face
 
             // Included font is used in the clock
 
-            var timer = new Timer(state =>
+            //Start timer for screen refresh and keep a reference
+            //so the refresh period can be update later.
+            _timerPeriod = Face.UpdateSpeed;
+            _timer = new Timer(state =>
             {
 
-               Render();
+                Render();
 
-            }, null, 1, Face.UpdateSpeed);
+            }, null, 1, _timerPeriod);
             
             Thread.Sleep(Timeout.Infinite);
         }

--- a/Agent.Contrib/Face/WatchFace.cs
+++ b/Agent.Contrib/Face/WatchFace.cs
@@ -12,6 +12,15 @@ namespace Agent.Contrib.Face
         public IFace Face { get; set; }
         public Bitmap Screen { get; set; }
 
+        /// <summary>
+        /// Reference to the internal timer used to refresh the face
+        /// </summary>
+        private Timer _timer;
+        /// <summary>
+        /// Timer interval in ms
+        /// </summary>
+        private int _timerPeriod;
+
         public void Render()
         {
 
@@ -26,7 +35,12 @@ namespace Agent.Contrib.Face
             //flush the image out to the device
             Screen.Flush();
 
-
+            //Update the timer period if it has been changed
+            if (_timerPeriod != Face.UpdateSpeed)
+            {
+                _timerPeriod = Face.UpdateSpeed;
+                _timer.Change(1, _timerPeriod);
+            }
         }
         public WatchFace(IFace face, Bitmap screen = null, ISettings settings = null)
         {            
@@ -44,12 +58,14 @@ namespace Agent.Contrib.Face
 
             // Included font is used in the clock
 
-            var timer = new Timer(state =>
+            // Store the timer reference so we can change period later if required
+            _timerPeriod = Face.UpdateSpeed;
+            _timer = new Timer(state =>
             {
 
-               Render();
+                Render();
 
-            }, null, 1, Face.UpdateSpeed);
+            }, null, 1, _timerPeriod);
             
             Thread.Sleep(Timeout.Infinite);
         }


### PR DESCRIPTION
Hello,

I made a small change to WatchFace.cs in order to make the internal timer's period dynamic.

The idea is to check at each tick if the UpdateSpeed of the face has changed and to set the timer's period accordingly. I had a use for this by implementing a StopWatch face. When the stopwatch is running, I need a very short update frequency. But when the stopwatch is not running, I can go with a longer frequency. I suppose this can have a positive impact on battery life.

I'm a little unpleased by the fact that the code will check the UpdateSpeed property at each Render. Better, but more invasive option, would be that IFace exposes an event "UpdateSpeedChanged" and that WatchFace subscribes to this event. 

This would, however, I think, be a breaking change. So I prefer to check with you what you think about it. Feel free to contact me if you want to discuss the topic.

Philippe HERTZOG
